### PR TITLE
Greenfield: Rename API key redirect params; switch to POST body (#1898)

### DIFF
--- a/BTCPayServer.Tests/BTCPayServer.Tests.csproj
+++ b/BTCPayServer.Tests/BTCPayServer.Tests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.13" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="83.0.4103.3900" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="85.0.4183.8700" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>

--- a/BTCPayServer.Tests/SeleniumTester.cs
+++ b/BTCPayServer.Tests/SeleniumTester.cs
@@ -308,8 +308,9 @@ namespace BTCPayServer.Tests
             currencyEl.Clear();
             currencyEl.SendKeys(currency);
             Driver.FindElement(By.Id("BuyerEmail")).SendKeys(refundEmail);
-            Driver.FindElement(By.Name("StoreId")).SendKeys(storeName + Keys.Enter);
-            Driver.FindElement(By.Id("Create")).ForceClick();
+            Driver.FindElement(By.Name("StoreId")).SendKeys(storeName);
+            Driver.FindElement(By.Id("Create")).Click();
+
             Assert.True(Driver.PageSource.Contains("just created!"), "Unable to create Invoice");
             var statusElement = Driver.FindElement(By.ClassName("alert-success"));
             var id = statusElement.Text.Split(" ")[1];

--- a/BTCPayServer/BTCPayServer.csproj
+++ b/BTCPayServer/BTCPayServer.csproj
@@ -43,7 +43,7 @@
     <Content Remove="Views\Shared\Ethereum\**\*" />
     <Content Remove="Views\Shared\Monero\**\*" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="BTCPayServer.Hwi" Version="1.1.3" />
     <PackageReference Include="BTCPayServer.Lightning.All" Version="1.2.4" />

--- a/BTCPayServer/Controllers/HomeController.cs
+++ b/BTCPayServer/Controllers/HomeController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -12,6 +13,7 @@ using BTCPayServer.Security;
 using BTCPayServer.Services.Apps;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.FileProviders;
@@ -139,7 +141,6 @@ namespace BTCPayServer.Controllers
             return View();
         }
 
-
         [HttpPost]
         [Route("translate")]
         public async Task<IActionResult> BitpayTranslator(BitpayTranslatorViewModel vm)
@@ -197,6 +198,18 @@ namespace BTCPayServer.Controllers
         public IActionResult RecoverySeedBackup(RecoverySeedBackupViewModel vm)
         {
             return View("RecoverySeedBackup", vm);
+        }
+
+        [HttpPost]
+        [Route("postredirect-callback-test")]
+        public ActionResult PostRedirectCallbackTestpage(IFormCollection data)
+        {
+            var list = data.Keys.Aggregate(new Dictionary<string, string>(), (res, key) =>
+            {
+                res.Add(key, data[key]);
+                return res;
+            });
+            return Json(list);
         }
 
         public IActionResult Error()

--- a/BTCPayServer/Models/PostRedictViewModel.cs
+++ b/BTCPayServer/Models/PostRedictViewModel.cs
@@ -6,6 +6,8 @@ namespace BTCPayServer.Models
     {
         public string AspAction { get; set; }
         public string AspController { get; set; }
+        public string FormUrl { get; set; }
+
         public List<KeyValuePair<string, string>> Parameters { get; set; } = new List<KeyValuePair<string, string>>();
     }
 }

--- a/BTCPayServer/Views/Manage/APIKeys.cshtml
+++ b/BTCPayServer/Views/Manage/APIKeys.cshtml
@@ -34,7 +34,7 @@
                     <ul>
                         @foreach (var permission in Permission.ToPermissions(permissions).Select(c => c.ToString()).Distinct().ToArray())
                         {
-                            <li>@permission</li>
+                            <li><code>@permission</code></li>
                         }
                     </ul>
                 }

--- a/BTCPayServer/Views/Manage/AuthorizeAPIKey.cshtml
+++ b/BTCPayServer/Views/Manage/AuthorizeAPIKey.cshtml
@@ -18,16 +18,15 @@
     <input type="hidden" asp-for="SelectiveStores" value="@Model.SelectiveStores"/>
     <input type="hidden" asp-for="ApplicationIdentifier" value="@Model.ApplicationIdentifier"/>
     <section>
-        <div class="card container">
+        <div class="container">
             <div class="row">
                 <div class="col-lg-12 section-heading">
                     <h2>Authorization Request</h2>
-                    <hr class="primary">
-                    <p class="mb-1">@(Model.ApplicationName ?? "An application") is requesting access to your account.</p>
+                    <p class="my-3">@(Model.ApplicationName ?? "An application") is requesting access to your account.</p>
                     @if (Model.RedirectUrl != null)
                     {
                         <p class="mb-1 alert alert-info">
-                        If authorized, the generated API key will be provided to <strong>@Model.RedirectUrl.AbsoluteUri</strong>
+                            If authorized, the generated API key will be provided to <strong>@Model.RedirectUrl.AbsoluteUri</strong>
                         </p>
                     }
                 </div>
@@ -174,13 +173,10 @@
                     }
                 </div>
             </div>
-            <div class="row my-2">
+            <div class="row my-4">
                 <div class="col-lg-12 text-center">
-                    <div class="btn-group">
-                        <button class="btn btn-primary" name="command" id="consent-yes" type="submit" value="Yes">Authorize app</button>
-                    </div>
-                    <button class="btn btn-secondary" id="consent-no" name="command" type="submit" value="No">Cancel</button>
-
+                    <button class="btn btn-primary mx-2" name="command" id="consent-yes" type="submit" value="Authorize">Authorize app</button>
+                    <button class="btn btn-secondary mx-2" name="command" id="consent-no" type="submit" value="Cancel">Cancel</button>
                 </div>
             </div>
         </div>

--- a/BTCPayServer/Views/Manage/ConfirmAPIKey.cshtml
+++ b/BTCPayServer/Views/Manage/ConfirmAPIKey.cshtml
@@ -1,0 +1,41 @@
+@model BTCPayServer.Controllers.ManageController.AuthorizeApiKeysViewModel
+
+@{
+    var displayName = Model.ApplicationName ?? Model.ApplicationIdentifier;
+    ViewData["Title"] = $"Are you sure about exposing your API Key to {displayName}?";
+    Layout = null;
+}
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <partial name="Header" />
+</head>
+<body class="bg-light">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title w-100 text-center">@ViewData["Title"]</h4>
+            </div>
+
+            <div class="modal-body text-center">
+                You've previously generated the API Key <code>@Model.ApiKey</code> specifically for
+                <strong>@displayName</strong> with the URL <code>@Model.RedirectUrl</code>.
+            </div>
+
+            <form method="post" class="modal-footer justify-content-center" asp-controller="Manage" asp-action="AuthorizeAPIKey">
+                <input type="hidden" asp-for="ApplicationName" value="@Model.ApplicationName"/>
+                <input type="hidden" asp-for="ApplicationIdentifier" value="@Model.ApplicationIdentifier"/>
+                <input type="hidden" asp-for="ApiKey" value="@Model.ApiKey"/>
+                <input type="hidden" asp-for="Strict" value="@Model.Strict"/>
+                <input type="hidden" asp-for="RedirectUrl" value="@Model.RedirectUrl"/>
+                <input type="hidden" asp-for="Permissions" value="@Model.Permissions"/>
+                <input type="hidden" asp-for="SelectiveStores" value="@Model.SelectiveStores"/>
+
+                <button type="submit" class="btn btn-primary w-25 mx-2" id="continue" name="command" value="Confirm">Confirm</button>
+                <button type="submit" class="btn btn-secondary w-25 mx-2" onclick="history.back(); return false;">Go back</button>
+            </form>
+        </div>
+    </div>
+</body>
+</html>

--- a/BTCPayServer/Views/Shared/Confirm.cshtml
+++ b/BTCPayServer/Views/Shared/Confirm.cshtml
@@ -16,33 +16,25 @@
             <div class="modal-header">
                 <h4 class="modal-title w-100 text-center">@Model.Title</h4>
             </div>
-            <div class="modal-body">
-                <div class="row">
-                    <div class="col-lg-12 text-center">
-                        <p>
-                            @if (Model.DescriptionHtml)
-                            {
-                                @Safe.Raw(Model.Description)
-                            }
-                            else
-                            {
-                                @Model.Description
-                            }
-                        </p>
-                    </div>
-                </div>
-                @if (!String.IsNullOrEmpty(Model.Action))
+
+            <div class="modal-body text-center">
+                @if (Model.DescriptionHtml)
                 {
-                    <div class="row">
-                        <div class="col-lg-12 text-center">
-                            <form method="post" action="@Model.ActionUrl">
-                                <button id="continue" type="submit" class="btn @Model.ButtonClass w-25">@Model.Action</button>
-                                <button type="submit" class="btn btn-secondary w-25" onclick="history.back(); return false;">Go back</button>
-                            </form>
-                        </div>
-                    </div>
+                    @Safe.Raw(Model.Description)
+                }
+                else
+                {
+                    @Model.Description
                 }
             </div>
+
+            @if (!String.IsNullOrEmpty(Model.Action))
+            {
+                <form method="post" class="modal-footer justify-content-center" action="@Model.ActionUrl">
+                    <button type="submit" class="btn @Model.ButtonClass w-25 mx-2" id="continue">@Model.Action</button>
+                    <button type="submit" class="btn btn-secondary w-25 mx-2" onclick="history.back(); return false;">Go back</button>
+                </form>
+            }
         </div>
     </div>
 </body>

--- a/BTCPayServer/Views/Shared/PostRedirect.cshtml
+++ b/BTCPayServer/Views/Shared/PostRedirect.cshtml
@@ -8,22 +8,34 @@
     {
         routeParams["walletId"] = routeData.Values["walletId"]?.ToString();
     }
+    var action = Model.FormUrl ?? Url.Action(Model.AspAction, Model.AspController, routeParams);
 }
 
-<html>
-<head></head>
+<html lang="en">
+<head>
+    <partial name="Header" />
+    <title>Post Redirect</title>
+</head>
 <body>
-    <form
-        method="post"
-        id="postform"
-        asp-action="@Model.AspAction"
-        asp-controller="@Model.AspController"
-        asp-all-route-data="@routeParams"
-    >
-        @foreach(var o in Model.Parameters) {
-            <input type="hidden" name="@o.Key" value="@o.Value" />
-        }
-    </form>
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <form method="post" id="postform" action="@action" class="modal-body text-center my-3">
+                @Html.AntiForgeryToken()
+                @foreach (var o in Model.Parameters)
+                {
+                    <input type="hidden" name="@o.Key" value="@o.Value"/>
+                }
+                <noscript>
+                    <p>
+                        This redirection page is supposed to be submitted automatically.
+                        <br>
+                        Since you have not enabled JavaScript, please submit manually.
+                    </p>
+                    <button class="btn btn-primary" type="submit">Submit</button>
+                </noscript>
+            </form>
+        </div>
+    </div>
     <script type="text/javascript">
         document.forms.item(0).submit();
     </script>

--- a/BTCPayServer/wwwroot/swagger/v1/swagger.template.authorization.json
+++ b/BTCPayServer/wwwroot/swagger/v1/swagger.template.authorization.json
@@ -86,7 +86,7 @@
                         }
                     },
                     "307": {
-                        "description": "Redirects to the specified url in `redirect` with query string values for `key` (the api key created or matched), `permissions` (the permissions the user consented to), and `user` (the id of the user that consented) upon consent"
+                        "description": "Makes browser do an HTTP POST request to the specified url in `redirect` with a JSON body consisting of `apiKey` (the api key created or matched), `permissions` (the permissions the user consented to), and `userId` (the id of the user that consented) upon consent"
                     }
                 },
                 "security": []


### PR DESCRIPTION
* Rename user param to userId in API key redirect

This way it is clearer what to expect and it also make the parameteer easier to consume.

* Post redirect: Allow form url and prettify page

- Form URL as alternative to controller/action for external URLs
- Making it look nice and add explanation for non-JS case

* APIKeys: Minor view updates

fix

* APIKeys: Use POST redirect for confirmation

fix

* UI: Minor update to confirm view

Tidies it up and adapts to the newly added ConfirmAPIKeys view.

* APIKeys: Update delete view

Structures the information in title and description better.

* APIKeys: Distinguish authorize and confirm (reuse)

* Upgrade ChromeDriver

* Test fixes

* Clean up PostRedirect view

By adding missing forgery token

* Re-add tests for callback post values

* Rename key param to apiKey in API key redirect

* Update BTCPayServer/wwwroot/swagger/v1/swagger.template.authorization.json

Co-authored-by: Andrew Camilleri <evilkukka@gmail.com>

* Use DEBUG conditional for postredirect-callback-test route

* Remove unnecessary ChromeDriver references

* Add debug flag

* Remove debug flags

Co-authored-by: Andrew Camilleri <evilkukka@gmail.com>